### PR TITLE
Update deps version and convert commented test into ignore

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,14 +8,16 @@ version := "0.6-SNAPSHOT"
 
 scalaVersion := "2.11.7"
 
-crossScalaVersions := Seq("2.11.7", "2.10.5")
+crossScalaVersions := Seq("2.11.7", "2.10.6")
 
 scalacOptions ++= Seq("-unchecked", "-deprecation")
 
 libraryDependencies ++= Seq(
-  "org.scalatest"   %% "scalatest"  % "2.2.5"   % Test,
-  "org.scalacheck"  %% "scalacheck" % "1.12.4"  % Test
+  "org.scalatest"   %% "scalatest"  % "2.2.6"   % Test,
+  "org.scalacheck"  %% "scalacheck" % "1.12.5"  % Test
 )
+
+resolvers += "Sonatype OSS Releases" at "https://oss.sonatype.org/service/local/staging/deploy/maven2"
 
 /// Scalariform
 scalariformSettings

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,9 @@
 resolvers += Classpaths.sbtPluginReleases
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.4")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.5")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "0.5.0")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
-

--- a/src/test/scala/io/github/nremond/PBKDF2Spec.scala
+++ b/src/test/scala/io/github/nremond/PBKDF2Spec.scala
@@ -42,10 +42,10 @@ class PBKDF2Spec extends FlatSpec with Matchers {
     pbkdf2("password", "salt", 4096, 20, "HmacSHA1") should equal("4b007901b765489abead49d926f721d065a429c1")
   }
 
-  // It takes too long, I'm commenting it. 
-  //  it should " "work with the 3rd test vector"" in {
-  //    sha1Pbkdf2.encrypt("password", "salt", 16777216, 20) should equal("eefe3d61cd4da4e4e9945b3d6ba2158c2634e984")
-  //  }
+  // It takes too long, I'm ignoring it.
+  ignore should "work with the 3rd test vector" in {
+    pbkdf2("password", "salt", 16777216, 20, "HmacSHA1") should equal("eefe3d61cd4da4e4e9945b3d6ba2158c2634e984")
+  }
 
   it should "work with the 4th test vector" in {
     pbkdf2("passwordPASSWORDpassword", "saltSALTsaltSALTsaltSALTsaltSALTsalt", 4096, 25, "HmacSHA1") should equal("3d2eec4fe41c849b80c8d83662c0e44a8b291a964cf2f07038")


### PR DESCRIPTION
- update various lib/language/plugin dependency
- make an old commented out test into `ignore` provided by scalatest