### PR TITLE
fix legacy.SecureHash.validatePassword when a new hash is provided to it

### DIFF
--- a/src/main/scala/io/github/nremond/legacy/SecureHash.scala
+++ b/src/main/scala/io/github/nremond/legacy/SecureHash.scala
@@ -83,9 +83,11 @@ case class SecureHash(iterations: Int = 20000, dkLength: Int = 32, cryptoAlgo: S
 
   private[this] def legacyValidatePassword(password: String, hashedPassword: String): Boolean = {
     val params = hashedPassword.split(":")
-    assert(params.size == 2)
-    val salt = fromHex(params(0))
-    val hash = PBKDF2(password.getBytes(UTF_8), salt, iterations, dkLength, cryptoAlgo)
-    Arrays.equals(fromHex(params(1)), hash)
+    if (params.size == 2) {
+      val salt = fromHex(params(0))
+      val hash = PBKDF2(password.getBytes(UTF_8), salt, iterations, dkLength, cryptoAlgo)
+      Arrays.equals(fromHex(params(1)), hash)
+    } else
+      false
   }
 }

--- a/src/test/scala/io/github/nremond/SecureHashSpec.scala
+++ b/src/test/scala/io/github/nremond/SecureHashSpec.scala
@@ -85,6 +85,12 @@ class SecureHashSpec extends FlatSpec with Matchers with Inspectors {
     SecureHash.validatePassword(password, incorrectHash) should be(false)
   }
 
+  it should "only validate correct password using legacy validate method" in {
+    val password = "secret_password"
+    val incorrectHash = "$pbkdf2-sha256$6400$.6UI/S.nXIk8jcbdHx3Fhg$98jZicV16ODfEsEZeYPGHU3kbrUrvUEXOPimVSQDD44"
+    legacy.SecureHash().validatePassword(password, incorrectHash) should be(false)
+  }
+
   it should "be compatible with Passlib" in {
     // Exemples from: https://pythonhosted.org/passlib/lib/passlib.hash.pbkdf2_digest.html
     val hashs = Vector("$pbkdf2-sha256$6400$0ZrzXitFSGltTQnBWOsdAw$Y11AchqV4b0sUisdZd0Xr97KWoymNE0LNNrnEgY4H9M",


### PR DESCRIPTION
I'm sorry, I missed this in my last PR. The legacy validate method would fail with assertion error if it was fed a new hash and an invalid password.
Can you please review & release if ok?
Thanks