### PR TITLE
Update plugin versions to resolve for Scala 2.12.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,4 @@
+import com.typesafe.sbt.SbtScalariform.ScalariformKeys
 import scalariform.formatter.preferences._
 
 name := "pbkdf2-scala"
@@ -18,10 +19,10 @@ libraryDependencies ++= Seq(
 resolvers += "Sonatype OSS Releases" at "https://oss.sonatype.org/service/local/staging/deploy/maven2"
 
 /// Scalariform
-scalariformSettings
+scalariformAutoformat := true
 
-ScalariformKeys.preferences := ScalariformKeys.preferences.value
-      .setPreference(DoubleIndentClassDeclaration, true)
+scalariformPreferences := ScalariformKeys.preferences.value
+      .setPreference(DoubleIndentConstructorArguments, true)
       .setPreference(AlignParameters, true)
       .setPreference(AlignSingleLineCaseStatements, true)
       .setPreference(IndentLocalDefs, true)
@@ -60,9 +61,9 @@ releaseProcess := Seq[ReleaseStep](
   setReleaseVersion,
   commitReleaseVersion,
   tagRelease,
-  ReleaseStep(action = Command.process("publishSigned", _), enableCrossBuild = true),
+  ReleaseStep(releaseStepCommand("publishSigned"), enableCrossBuild = true),
   setNextVersion,
   commitNextVersion,
-  ReleaseStep(action = Command.process("sonatypeReleaseAll", _), enableCrossBuild = true),
+  ReleaseStep(releaseStepCommand("sonatypeReleaseAll"), enableCrossBuild = true),
   pushChanges
 )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,11 +1,11 @@
 resolvers += Classpaths.sbtPluginReleases
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.2")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.4")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.3")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.11")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")


### PR DESCRIPTION
Update deprecated scalariform and release keys, e.g.:    pbkdf2-scala/build.sbt:22: warning: method scalariformSettings in object autoImport is deprecated (since 1.8.1): Use scalariformAutoformat to turn autoformat on or off    scalariformSettings(true)    pbkdf2-scala/build.sbt:25: warning: object DoubleIndentClassDeclaration in package preferences is deprecated (since 0.2.0): This has been dropped in favor of DoubleIndentConstructorArguments.          .setPreference(DoubleIndentClassDeclaration, true)
Eliminate unresolved Dependencies:
[warn] 	::          UNRESOLVED DEPENDENCIES         ::
[warn] 	::::::::::::::::::::::::::::::::::::::::::::::
[warn] 	:: org.scoverage#sbt-scoverage;1.5.0: not found
[warn] 	:: com.jsuereth#sbt-pgp;1.0.0: not found
[warn] 	:: org.xerial.sbt#sbt-sonatype;1.1: not found
[warn] 	:: com.github.gseitz#sbt-release;1.0.3: not found
[warn] 	:: com.typesafe.sbt#sbt-scalariform;1.3.0: not found