### PR TITLE
Increase iteration count to 210000

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,7 @@ should be set as high as possible, to make attacks as difficult as possible,
 without making legitimate applications unusably slow. 
 
 [Security Considerations section of RFC 3962][ITERS] provides a useful example 
-on how to consider that choice.
-
-The current default value is set to 20k. 
+on how to consider that choice.The current default value is set to 210000, based on the [OWASP Cheat Sheet Series][OWASP]. 
 
 ## Using the library
 
@@ -38,7 +36,7 @@ You can use the raw PBKDF2 function which as the following signature:
 object PBKDF2 {
   def apply(password: Array[Byte], 
             salt: Array[Byte], 
-            iterations: Int = 120000, 
+            iterations: Int = 210000, 
             dkLength: Int = 32, 
             cryptoAlgo: String = "HmacSHA512"): Array[Byte]
 }
@@ -49,7 +47,7 @@ Alternatively, you can use the following functions that will handle the salting 
 ```scala
 object SecureHash {
   def createHash(password: String,
-                 iterations: Int = 120000,
+                 iterations: Int = 210000,
                  dkLength: Int = 32,
                  cryptoAlgo: String = "HmacSHA512"): String
 
@@ -91,3 +89,4 @@ See the `license.txt` file for the terms under which it may be used and distribu
 [ITERS]: https://tools.ietf.org/html/rfc3962#page-6 "RFC 3962: Section 8"
 [NIST]: https://csrc.nist.gov/groups/ST/hash/statement.html "NIST Comments on Cryptanalytic Attacks on SHA-1"
 [PASS_LIB]: https://pythonhosted.org/passlib/lib/passlib.hash.pbkdf2_digest.html "PassLib"
+[OWASP]: https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html "OWASP: Password Storage Cheat Sheet"

--- a/src/main/scala/io/github/nremond/PBKDF2.scala
+++ b/src/main/scala/io/github/nremond/PBKDF2.scala
@@ -39,7 +39,7 @@ object PBKDF2 {
    *
    * HMAC+SHA256 is used as the default pseudo random function.
    *
-   * Right now 120000 iterations is the strictly recommended default minimum.
+   * Right now 210000 iterations is the strictly recommended default minimum.
    * https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#pbkdf2
    * The minimum increases every year, please keep that in mind.
    *
@@ -50,7 +50,7 @@ object PBKDF2 {
    * @param cryptoAlgo HMAC+SHA512 is the default and note that HMAC+SHA1 is now considered weak
    * @return the hashed password
    */
-  def apply(password: Array[Byte], salt: Array[Byte], iterations: Int = 120000, dkLength: Int = 32, cryptoAlgo: String = "HmacSHA512"): Array[Byte] = {
+  def apply(password: Array[Byte], salt: Array[Byte], iterations: Int = 210000, dkLength: Int = 32, cryptoAlgo: String = "HmacSHA512"): Array[Byte] = {
 
     val mac = crypto.Mac.getInstance(cryptoAlgo)
     mac.init(new crypto.spec.SecretKeySpec(password, "RAW"))

--- a/src/main/scala/io/github/nremond/SecureHash.scala
+++ b/src/main/scala/io/github/nremond/SecureHash.scala
@@ -49,12 +49,12 @@ object SecureHash {
    * p0\$00004e20HmacSHA256\$mOCtN/Scjry0uIALe4bCCrL9eL8aWEA/\$hDxtqCnBF1MS5qIOxHeDAZ23QEmqdL7796I0pVJ2yvQ
    *
    * @param password  the password to hash
-   * @param iterations the number of encryption iterations, default to 120000
+   * @param iterations the number of encryption iterations, default to 210000
    * @param dkLength derived-key length, default to 32
    * @param cryptoAlgo HMAC+SHA512 is the default as HMAC+SHA1 is now considered weak
    * @param saltLength length of the salt, default to 24
    */
-  def createHash(password: String, iterations: Int = 120000,
+  def createHash(password: String, iterations: Int = 210000,
                  dkLength: Int = 32, cryptoAlgo: String = "HmacSHA512", saltLength: Int = 24): String = {
     val salt = {
       val b = new Array[Byte](saltLength)

--- a/src/main/scala/io/github/nremond/legacy/SecureHash.scala
+++ b/src/main/scala/io/github/nremond/legacy/SecureHash.scala
@@ -27,11 +27,11 @@ import scala.annotation.tailrec
 /**
  *  This is the legacy API.
  *
- * @param iterations the number of encryption iterations. Default to 120000
+ * @param iterations the number of encryption iterations. Default to 210000
  * @param dkLength derived-key length, default to 32
  * @param cryptoAlgo HMAC+SHA512 is the default as HMAC+SHA1 is now considered weak
  */
-case class SecureHash(iterations: Int = 120000, dkLength: Int = 32, cryptoAlgo: String = "HmacSHA512") {
+case class SecureHash(iterations: Int = 210000, dkLength: Int = 32, cryptoAlgo: String = "HmacSHA512") {
 
   /**
    * Creates a hashed password using [[PBKDF2]]


### PR DESCRIPTION
Based on the latest updates to the OWASP project.

---

Background: Two years ago, I made a merge-request to update the iteration count to 120000 (https://github.com/nremond/pbkdf2-scala/pull/14), which was good enough at the time. Sadly, the strength of the ageing PBKDF2 is directly related to Nvidia's top-op-the-line graphics card. With one 4090, you can now brute-force more passwords in the same amount of time.

The team behind the OWASP cheat-sheet discussed it here: https://github.com/OWASP/CheatSheetSeries/issues/1043

And the maths behind it are here: https://tobtu.com/minimum-password-settings/